### PR TITLE
Fix inventory desync caused by wrong window validation

### DIFF
--- a/src/protocolsupport/protocol/packet/middle/clientbound/play/MiddleInventorySetItems.java
+++ b/src/protocolsupport/protocol/packet/middle/clientbound/play/MiddleInventorySetItems.java
@@ -10,6 +10,8 @@ import protocolsupport.protocol.utils.types.NetworkItemStack;
 
 public abstract class MiddleInventorySetItems extends ClientBoundMiddlePacket {
 
+	protected static final int WINDOW_ID_PLAYER_INVENTORY = 0;
+
 	public MiddleInventorySetItems(ConnectionImpl connection) {
 		super(connection);
 	}
@@ -29,7 +31,7 @@ public abstract class MiddleInventorySetItems extends ClientBoundMiddlePacket {
 
 	@Override
 	public boolean postFromServerRead() {
-		return cache.getWindowCache().isValidWindowId(windowId);
+		return cache.getWindowCache().isValidWindowId(windowId) || windowId == WINDOW_ID_PLAYER_INVENTORY;
 	}
 
 }

--- a/src/protocolsupport/protocol/packet/middle/clientbound/play/MiddleInventorySetSlot.java
+++ b/src/protocolsupport/protocol/packet/middle/clientbound/play/MiddleInventorySetSlot.java
@@ -8,6 +8,10 @@ import protocolsupport.protocol.utils.types.NetworkItemStack;
 
 public abstract class MiddleInventorySetSlot extends ClientBoundMiddlePacket {
 
+	protected static final int WINDOW_ID_PLAYER_HOTBAR = 0;
+	protected static final int WINDOW_ID_PLAYER_CURSOR = 255;
+	protected static final int WINDOW_ID_PLAYER_INVENTORY = 254;
+
 	public MiddleInventorySetSlot(ConnectionImpl connection) {
 		super(connection);
 	}
@@ -25,7 +29,11 @@ public abstract class MiddleInventorySetSlot extends ClientBoundMiddlePacket {
 
 	@Override
 	public boolean postFromServerRead() {
-		return cache.getWindowCache().isValidWindowId(windowId);
+		return
+			cache.getWindowCache().isValidWindowId(windowId) ||
+			windowId == WINDOW_ID_PLAYER_HOTBAR ||
+			windowId == WINDOW_ID_PLAYER_CURSOR ||
+			windowId == WINDOW_ID_PLAYER_INVENTORY;
 	}
 
 }

--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_4_5_6_7_8_9r1_9r2_10_11_12r1_12r2_13/InventoryData.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_4_5_6_7_8_9r1_9r2_10_11_12r1_12r2_13/InventoryData.java
@@ -20,7 +20,7 @@ public class InventoryData extends MiddleInventoryData {
 
 	@Override
 	public RecyclableCollection<ClientBoundPacketData> toData() {
-		if ((version == ProtocolVersion.MINECRAFT_1_8) && (cache.getWindowCache().getOpenedWindow(windowId) == WindowType.ENCHANT)) {
+		if ((version == ProtocolVersion.MINECRAFT_1_8) && (cache.getWindowCache().getOpenedWindow() == WindowType.ENCHANT)) {
 			enchTypeVal[type] = value;
 			if ((type >= 7) && (type <= 9)) {
 				ClientBoundPacketData serializer = ClientBoundPacketData.create(ClientBoundPacket.PLAY_WINDOW_DATA_ID);
@@ -35,7 +35,7 @@ public class InventoryData extends MiddleInventoryData {
 				serializer.writeShort(((enchTypeVal[type + 3]) << 8) | value);
 				return RecyclableSingletonList.create(serializer);
 			}
-		} else if (version.isBefore(ProtocolVersion.MINECRAFT_1_8) && (cache.getWindowCache().getOpenedWindow(windowId) == WindowType.FURNACE)) {
+		} else if (version.isBefore(ProtocolVersion.MINECRAFT_1_8) && (cache.getWindowCache().getOpenedWindow() == WindowType.FURNACE)) {
 			if (type < furTypeTr.length) {
 				type = furTypeTr[type];
 			}

--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_4_5_6_7_8_9r1_9r2_10_11_12r1_12r2_13/InventorySetItems.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_4_5_6_7_8_9r1_9r2_10_11_12r1_12r2_13/InventorySetItems.java
@@ -7,6 +7,7 @@ import protocolsupport.protocol.packet.middleimpl.ClientBoundPacketData;
 import protocolsupport.protocol.serializer.ItemStackSerializer;
 import protocolsupport.protocol.typeremapper.basic.WindowSlotsRemappingHelper;
 import protocolsupport.protocol.utils.types.NetworkItemStack;
+import protocolsupport.protocol.utils.types.WindowType;
 import protocolsupport.utils.recyclable.RecyclableCollection;
 import protocolsupport.utils.recyclable.RecyclableSingletonList;
 
@@ -18,7 +19,8 @@ public class InventorySetItems extends MiddleInventorySetItems {
 
 	@Override
 	public RecyclableCollection<ClientBoundPacketData> toData() {
-		switch (cache.getWindowCache().getOpenedWindow(windowId)) {
+		WindowType window = windowId == WINDOW_ID_PLAYER_INVENTORY ? WindowType.PLAYER : cache.getWindowCache().getOpenedWindow();
+		switch (window) {
 			case PLAYER: {
 				if (!WindowSlotsRemappingHelper.hasPlayerOffhandSlot(version)) {
 					itemstacks.remove(WindowSlotsRemappingHelper.PLAYER_OFF_HAND_SLOT);

--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_4_5_6_7_8_9r1_9r2_10_11_12r1_12r2_13/InventorySetSlot.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_4_5_6_7_8_9r1_9r2_10_11_12r1_12r2_13/InventorySetSlot.java
@@ -18,39 +18,41 @@ public class InventorySetSlot extends MiddleInventorySetSlot {
 
 	@Override
 	public RecyclableCollection<ClientBoundPacketData> toData() {
-		switch (cache.getWindowCache().getOpenedWindow(windowId)) {
-			case PLAYER: {
-				if (!WindowSlotsRemappingHelper.hasPlayerOffhandSlot(version)) {
-					if (slot == WindowSlotsRemappingHelper.PLAYER_OFF_HAND_SLOT) {
-						return RecyclableEmptyList.get();
+		if (windowId != WINDOW_ID_PLAYER_HOTBAR && windowId != WINDOW_ID_PLAYER_CURSOR && windowId != WINDOW_ID_PLAYER_INVENTORY) {
+			switch (cache.getWindowCache().getOpenedWindow()) {
+				case PLAYER: {
+					if (!WindowSlotsRemappingHelper.hasPlayerOffhandSlot(version)) {
+						if (slot == WindowSlotsRemappingHelper.PLAYER_OFF_HAND_SLOT) {
+							return RecyclableEmptyList.get();
+						}
 					}
+					break;
 				}
-				break;
-			}
-			case BREWING: {
-				if (!WindowSlotsRemappingHelper.hasBrewingBlazePowderSlot(version)) {
-					if (slot == WindowSlotsRemappingHelper.BREWING_BLAZE_POWDER_SLOT) {
-						return RecyclableEmptyList.get();
+				case BREWING: {
+					if (!WindowSlotsRemappingHelper.hasBrewingBlazePowderSlot(version)) {
+						if (slot == WindowSlotsRemappingHelper.BREWING_BLAZE_POWDER_SLOT) {
+							return RecyclableEmptyList.get();
+						}
+						if (slot > WindowSlotsRemappingHelper.BREWING_BLAZE_POWDER_SLOT) {
+							slot--;
+						}
 					}
-					if (slot > WindowSlotsRemappingHelper.BREWING_BLAZE_POWDER_SLOT) {
-						slot--;
-					}
+					break;
 				}
-				break;
-			}
-			case ENCHANT: {
-				if (!WindowSlotsRemappingHelper.hasEnchantLapisSlot(version)) {
-					if (slot == WindowSlotsRemappingHelper.ENCHANT_LAPIS_SLOT) {
-						return RecyclableEmptyList.get();
+				case ENCHANT: {
+					if (!WindowSlotsRemappingHelper.hasEnchantLapisSlot(version)) {
+						if (slot == WindowSlotsRemappingHelper.ENCHANT_LAPIS_SLOT) {
+							return RecyclableEmptyList.get();
+						}
+						if (slot > WindowSlotsRemappingHelper.ENCHANT_LAPIS_SLOT) {
+							slot--;
+						}
 					}
-					if (slot > WindowSlotsRemappingHelper.ENCHANT_LAPIS_SLOT) {
-						slot--;
-					}
+					break;
 				}
-				break;
-			}
-			default: {
-				break;
+				default: {
+					break;
+				}
 			}
 		}
 		ClientBoundPacketData serializer = ClientBoundPacketData.create(ClientBoundPacket.PLAY_WINDOW_SET_SLOT_ID);

--- a/src/protocolsupport/protocol/packet/middleimpl/serverbound/play/v_4_5_6_7_8_9r1_9r2_10_11_12r1_12r2_13/InventoryClick.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/serverbound/play/v_4_5_6_7_8_9r1_9r2_10_11_12r1_12r2_13/InventoryClick.java
@@ -16,7 +16,7 @@ public class InventoryClick extends MiddleInventoryClick {
 	public void readFromClientData(ByteBuf clientdata) {
 		windowId = clientdata.readUnsignedByte();
 		slot = clientdata.readShort();
-		switch (cache.getWindowCache().getOpenedWindow(windowId)) {
+		switch (cache.getWindowCache().getOpenedWindow()) {
 			case BREWING: {
 				if (!WindowSlotsRemappingHelper.hasBrewingBlazePowderSlot(version) && (slot >= WindowSlotsRemappingHelper.BREWING_BLAZE_POWDER_SLOT)) {
 					slot++;

--- a/src/protocolsupport/protocol/storage/netcache/WindowCache.java
+++ b/src/protocolsupport/protocol/storage/netcache/WindowCache.java
@@ -15,20 +15,16 @@ public class WindowCache {
 		this.windowType = windowType;
 	}
 
-	public WindowType getOpenedWindow(int windowId) {
-		if (windowId == WINDOW_ID_PLAYER) {
-			return WindowType.PLAYER;
-		} else {
-			return windowType;
-		}
+	public WindowType getOpenedWindow() {
+		return windowType;
 	}
 
 	public boolean isValidWindowId(int windowId) {
-		return windowId == WINDOW_ID_PLAYER || windowId == this.windowId;
+		return windowId == this.windowId;
 	}
 
 	public void closeWindow() {
-		this.windowId = WINDOW_ID_PLAYER;
+		this.windowId = Integer.MAX_VALUE;
 		this.windowType = WindowType.PLAYER;
 	}
 


### PR DESCRIPTION
Special window ids are not universal, they are actually separate for
each packet. So we have to handle them in each packet transformer.
However how exactly those special window ids work needs to be checked
because additional remap may be needed for them.